### PR TITLE
db: wait until database is up before calling FindMigrations

### DIFF
--- a/controlplane/postgres/migrations/migrate.go
+++ b/controlplane/postgres/migrations/migrate.go
@@ -43,12 +43,12 @@ func Migrate(dsn string) error {
 	mate.Log = io.Discard
 	mate.MigrationsDir = []string{"./"}
 
-	if _, err := mate.FindMigrations(); err != nil {
-		return fmt.Errorf("find migrations: %w", err)
-	}
-
 	if err := mate.Wait(); err != nil {
 		return fmt.Errorf("wait migrations: %w", err)
+	}
+
+	if _, err := mate.FindMigrations(); err != nil {
+		return fmt.Errorf("find migrations: %w", err)
 	}
 
 	if err := mate.Migrate(); err != nil {


### PR DESCRIPTION
this is because `FindMigrations` creates a connection to the database. this call will fail if the database is currently not up.