### PR TITLE
controlplane: adjust image creation worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ What's missing for a working beta:
 **Requirements**
 * Linux kernel >= 6.6, tcx not supported (caused by `link.AttachTCX`)
 
+**Limitations**
+* Only single-platform OCI images can be built, so setups containing both `linux/arm64` and `linux/amd64` hosts is not possible as of now.
+
 ## License
 This project uses two different licenses: AGPLv3 and LGPLv3. Everything found under under the `api/` folder is licensed under LGPLv3 while everything else is covered by AGPLv3, if not stated otherwise.
 

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -39,16 +39,17 @@ func main() {
 	var (
 		logger                   = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 		fs                       = flag.NewFlagSet("controlplane", flag.ContinueOnError)
-		listenAddr               = fs.String("listen-address", ":9012", "address and port the control plane server listens on")                                                //nolint:lll
-		pgConnString             = fs.String("postgres-dsn", "", "connection string in the form of postgres://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]") //nolint:lll
-		grpcMaxMessageSize       = fs.Uint("grpc-max-message-size", 4000000, "maximum grpc message size in bytes")                                                             //nolint:lll
-		ociRegistry              = fs.String("oci-registry", "", "registry to use to pull and push images")                                                                    //nolint:lll
-		ociRegistryUser          = fs.String("oci-registry-user", "", "oci registry username used for authentication against configured oci registry")                         //nolint:lll
-		ociRegistryPass          = fs.String("oci-registry-pass", "", "oci registry password used for authentication against configured oci registry")                         //nolint:lll
-		baseImage                = fs.String("base-image", "", "base image to use for creating flavor version images")                                                         //nolint:lll
-		imageCacheDir            = fs.String("image-cache-dir", "/tmp/explorer-images", "directory used to cache base image")                                                  //nolint:lll
-		checkJobTimeout          = fs.Duration("checkpoint-job-timeout", 5*time.Minute, "when to abort the checkpointing job")                                                 //nolint:lll
-		checkStatusCheckInterval = fs.Duration("checkpoint-status-check-interval", 3*time.Second, "how often the status check endpoint for a checkpoint should be called")     //nolint:lll
+		listenAddr               = fs.String("listen-address", ":9012", "address and port the control plane server listens on")                                                                                   //nolint:lll
+		pgConnString             = fs.String("postgres-dsn", "", "connection string in the form of postgres://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]")                                    //nolint:lll
+		grpcMaxMessageSize       = fs.Uint("grpc-max-message-size", 4000000, "maximum grpc message size in bytes")                                                                                                //nolint:lll
+		ociRegistry              = fs.String("oci-registry", "", "registry to use to pull and push images")                                                                                                       //nolint:lll
+		ociRegistryUser          = fs.String("oci-registry-user", "", "oci registry username used for authentication against configured oci registry")                                                            //nolint:lll
+		ociRegistryPass          = fs.String("oci-registry-pass", "", "oci registry password used for authentication against configured oci registry")                                                            //nolint:lll
+		baseImage                = fs.String("base-image", "", "base image to use for creating flavor version images")                                                                                            //nolint:lll
+		imageCacheDir            = fs.String("image-cache-dir", "/tmp/explorer-images", "directory used to cache base image")                                                                                     //nolint:lll
+		imagePlatform            = fs.String("image-platform", "linux/amd64", "the platform that will be specified when pulling the base image. must match with all configured platformd hosts e.g. linux/amd64") //nolint:lll
+		checkJobTimeout          = fs.Duration("checkpoint-job-timeout", 5*time.Minute, "when to abort the checkpointing job")                                                                                    //nolint:lll
+		checkStatusCheckInterval = fs.Duration("checkpoint-status-check-interval", 3*time.Second, "how often the status check endpoint for a checkpoint should be called")                                        //nolint:lll
 	)
 	if err := ff.Parse(fs, os.Args[1:],
 		ff.WithEnvVarPrefix("CONTROLPLANE"),
@@ -66,6 +67,7 @@ func main() {
 			OCIRegistryPass:               *ociRegistryPass,
 			BaseImage:                     *baseImage,
 			ImageCacheDir:                 *imageCacheDir,
+			ImagePlatform:                 *imagePlatform,
 			CheckpointJobTimeout:          *checkJobTimeout,
 			CheckpointStatusCheckInterval: *checkStatusCheckInterval,
 		}

--- a/controlplane/config.go
+++ b/controlplane/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	OCIRegistryPass               string
 	BaseImage                     string
 	ImageCacheDir                 string
+	ImagePlatform                 string
 	CheckpointJobTimeout          time.Duration
 	CheckpointStatusCheckInterval time.Duration
 }

--- a/internal/image/service.go
+++ b/internal/image/service.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -37,7 +38,7 @@ import (
 
 type Service interface {
 	Push(ctx context.Context, img ociv1.Image, imgRef string) error
-	Pull(ctx context.Context, imgRef string) (ociv1.Image, error)
+	Pull(ctx context.Context, imgRef string, platform string) (ociv1.Image, error)
 }
 
 type service struct {
@@ -47,6 +48,7 @@ type service struct {
 	pullCacheDir string
 }
 
+// NewService creates a new instance of image.Service. Leave cacheDir empty to disable caching of pulled images.
 func NewService(logger *slog.Logger, registryUser string, registryPass string, cacheDir string) Service {
 	return &service{
 		logger:       logger,
@@ -73,7 +75,7 @@ func (s *service) Push(ctx context.Context, img ociv1.Image, imgRef string) erro
 		Password: s.registryPass,
 	}
 
-	s.logger.InfoContext(ctx, "pushing image", "ref", ref)
+	s.logger.InfoContext(ctx, "pushing image", "ref", ref.String())
 
 	if err := remote.Write(
 		ref,
@@ -87,7 +89,7 @@ func (s *service) Push(ctx context.Context, img ociv1.Image, imgRef string) erro
 	return nil
 }
 
-func (s *service) Pull(ctx context.Context, imgRef string) (ociv1.Image, error) {
+func (s *service) Pull(ctx context.Context, imgRef string, platform string) (img ociv1.Image, err error) {
 	ref, err := name.ParseReference(imgRef)
 	if err != nil {
 		return nil, fmt.Errorf("pull: parse image ref: %w", err)
@@ -96,25 +98,9 @@ func (s *service) Pull(ctx context.Context, imgRef string) (ociv1.Image, error) 
 	// linux does not allow slashes in filenames
 	path := fmt.Sprintf("%s/%s", s.pullCacheDir, strings.ReplaceAll(ref.Name(), "/", "_"))
 
-	img, err := tarball.ImageFromPath(path, nil)
-	if errors.Is(err, os.ErrNotExist) {
-		s.logger.InfoContext(ctx, "pulling image", "ref", ref, "path", path)
-		// TODO: view remote.DefaultTransport
-		tp := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-			ForceAttemptHTTP2: true,
-		}
-
-		auth := Auth{
-			Username: s.registryUser,
-			Password: s.registryPass,
-		}
-
-		img, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(tp), remote.WithContext(ctx))
-		if err != nil {
-			return nil, fmt.Errorf("pull image: %w", err)
+	defer func() {
+		if err != nil && s.pullCacheDir == "" {
+			return
 		}
 
 		if err := tarball.WriteToFile(path, ref, img); err != nil {
@@ -122,14 +108,67 @@ func (s *service) Pull(ctx context.Context, imgRef string) (ociv1.Image, error) 
 				ctx,
 				"failed to cache image",
 				"err", err,
-				"ref", ref,
+				"ref", ref.String(),
 			)
 		}
-		return img, nil
+	}()
+
+	if s.pullCacheDir != "" {
+		img, err = tarball.ImageFromPath(path, nil)
+		if errors.Is(err, os.ErrNotExist) {
+			img, err = s.pull(ctx, ref, platform)
+			if err != nil {
+				return nil, fmt.Errorf("pull image: %w", err)
+			}
+		}
+		if err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"failed to read cached image",
+				"ref", ref.String(),
+				"path", path,
+				"err", err,
+			)
+		}
 	}
 
+	img, err = s.pull(ctx, ref, platform)
 	if err != nil {
-		return nil, fmt.Errorf("read file: %v", err)
+		return nil, fmt.Errorf("pull image: %w", err)
+	}
+
+	return img, nil
+}
+
+func (s *service) pull(ctx context.Context, ref name.Reference, platform string) (ociv1.Image, error) {
+	s.logger.InfoContext(ctx, "pulling image", "ref", ref.String())
+	// TODO: view remote.DefaultTransport
+	tp := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		ForceAttemptHTTP2: true,
+	}
+
+	auth := Auth{
+		Username: s.registryUser,
+		Password: s.registryPass,
+	}
+
+	plat, err := ociv1.ParsePlatform(runtime.GOOS + "/" + runtime.GOARCH)
+	if err != nil {
+		return nil, fmt.Errorf("parse platform: %w", err)
+	}
+
+	img, err := remote.Image(
+		ref,
+		remote.WithAuth(auth),
+		remote.WithTransport(tp),
+		remote.WithContext(ctx),
+		remote.WithPlatform(*plat),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("remote image: %w", err)
 	}
 
 	return img, nil

--- a/internal/image/service.go
+++ b/internal/image/service.go
@@ -26,7 +26,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -155,7 +154,7 @@ func (s *service) pull(ctx context.Context, ref name.Reference, platform string)
 		Password: s.registryPass,
 	}
 
-	plat, err := ociv1.ParsePlatform(runtime.GOOS + "/" + runtime.GOARCH)
+	plat, err := ociv1.ParsePlatform(platform)
 	if err != nil {
 		return nil, fmt.Errorf("parse platform: %w", err)
 	}

--- a/internal/mock/image_service.go
+++ b/internal/mock/image_service.go
@@ -23,9 +23,9 @@ func (_m *MockImageService) EXPECT() *MockImageService_Expecter {
 	return &MockImageService_Expecter{mock: &_m.Mock}
 }
 
-// Pull provides a mock function with given fields: ctx, imgRef
-func (_m *MockImageService) Pull(ctx context.Context, imgRef string) (v1.Image, error) {
-	ret := _m.Called(ctx, imgRef)
+// Pull provides a mock function with given fields: ctx, imgRef, platform
+func (_m *MockImageService) Pull(ctx context.Context, imgRef string, platform string) (v1.Image, error) {
+	ret := _m.Called(ctx, imgRef, platform)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Pull")
@@ -33,19 +33,19 @@ func (_m *MockImageService) Pull(ctx context.Context, imgRef string) (v1.Image, 
 
 	var r0 v1.Image
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (v1.Image, error)); ok {
-		return rf(ctx, imgRef)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (v1.Image, error)); ok {
+		return rf(ctx, imgRef, platform)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) v1.Image); ok {
-		r0 = rf(ctx, imgRef)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) v1.Image); ok {
+		r0 = rf(ctx, imgRef, platform)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(v1.Image)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, imgRef)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, imgRef, platform)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -61,13 +61,14 @@ type MockImageService_Pull_Call struct {
 // Pull is a helper method to define mock.On call
 //   - ctx context.Context
 //   - imgRef string
-func (_e *MockImageService_Expecter) Pull(ctx interface{}, imgRef interface{}) *MockImageService_Pull_Call {
-	return &MockImageService_Pull_Call{Call: _e.mock.On("Pull", ctx, imgRef)}
+//   - platform string
+func (_e *MockImageService_Expecter) Pull(ctx interface{}, imgRef interface{}, platform interface{}) *MockImageService_Pull_Call {
+	return &MockImageService_Pull_Call{Call: _e.mock.On("Pull", ctx, imgRef, platform)}
 }
 
-func (_c *MockImageService_Pull_Call) Run(run func(ctx context.Context, imgRef string)) *MockImageService_Pull_Call {
+func (_c *MockImageService_Pull_Call) Run(run func(ctx context.Context, imgRef string, platform string)) *MockImageService_Pull_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -77,7 +78,7 @@ func (_c *MockImageService_Pull_Call) Return(_a0 v1.Image, _a1 error) *MockImage
 	return _c
 }
 
-func (_c *MockImageService_Pull_Call) RunAndReturn(run func(context.Context, string) (v1.Image, error)) *MockImageService_Pull_Call {
+func (_c *MockImageService_Pull_Call) RunAndReturn(run func(context.Context, string, string) (v1.Image, error)) *MockImageService_Pull_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/test/fixture/postgres.go
+++ b/test/fixture/postgres.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -131,6 +132,7 @@ func (p *Postgres) CreateRiverClient(t *testing.T) {
 		1*time.Second,
 		p.DB,
 		p.DB,
+		runtime.GOOS+"/"+runtime.GOARCH,
 	)
 	require.NoError(t, err)
 

--- a/test/functional/image_service_test.go
+++ b/test/functional/image_service_test.go
@@ -49,7 +49,7 @@ func TestImagePull(t *testing.T) {
 	err := service.Push(ctx, imgtestdata.Image(t), ref)
 	require.NoError(t, err)
 
-	_, err = service.Pull(ctx, ref)
+	_, err = service.Pull(ctx, ref, "linux/amd64")
 	require.NoError(t, err)
 
 	require.FileExists(t, cacheDir+"/"+strings.ReplaceAll(ref, "/", "_"))


### PR DESCRIPTION
- only pull images with platform specified by environment variable CONTROLPLANE_IMAGE_PLATFORM. this is needs to match with the platformd hosts. if platformd hosts have a different platform than the pulled image, creating the checkpoint will not work.
- set status to IMAGE_BUILD_FAILED when max retries reached
- add linear retry policy to jobs (at the moment hardcoded to 5 sec.)