### PR TITLE
platformd: make checkpoint visible to workload store

### DIFF
--- a/platformd/checkpoint/service_test.go
+++ b/platformd/checkpoint/service_test.go
@@ -92,7 +92,16 @@ func TestCollectGarbage(t *testing.T) {
 				logger     = slog.New(slog.NewTextHandler(os.Stdout, nil))
 				store      = checkpoint.NewStore()
 				mockCRISvc = mock.NewMockCriService(t)
-				svc        = checkpoint.NewService(logger, tt.cfg, mockCRISvc, nil, store, nil)
+				svc        = checkpoint.NewService(
+					logger,
+					tt.cfg,
+					mockCRISvc,
+					nil,
+					store,
+					nil,
+					workload.NewStore(),
+					workload.NewPortAllocator(1, 1),
+				)
 			)
 
 			for id, status := range tt.storeItems {

--- a/platformd/config.go
+++ b/platformd/config.go
@@ -2,8 +2,6 @@ package platformd
 
 import (
 	"time"
-
-	"github.com/spacechunks/explorer/platformd/checkpoint"
 )
 
 type Config struct {
@@ -24,5 +22,16 @@ type Config struct {
 	RegistryUser               string
 	RegistryPass               string
 	ControlPlaneEndpoint       string
-	CheckpointConfig           checkpoint.Config
+	CheckpointConfig           struct {
+		CPUPeriod                int64
+		CPUQuota                 int64
+		MemoryLimitBytes         int64
+		CheckpointFileDir        string
+		CheckpointTimeoutSeconds int64
+		RegistryUser             string
+		RegistryPass             string
+		ListenAddr               string
+		StatusRetentionPeriod    time.Duration
+		ContainerReadyTimeout    time.Duration
+	}
 }

--- a/platformd/reconciler.go
+++ b/platformd/reconciler.go
@@ -261,7 +261,7 @@ func (r *reconciler) handleInstanceCreation(ctx context.Context, instance *insta
 
 	var (
 		baseURL = fmt.Sprintf(
-			"%s/",
+			"%s/%s/%s",
 			r.cfg.RegistryEndpoint,
 			instance.GetChunk().GetName(),
 			instance.GetFlavor().GetName(),

--- a/platformd/reconciler.go
+++ b/platformd/reconciler.go
@@ -263,7 +263,7 @@ func (r *reconciler) handleInstanceCreation(ctx context.Context, instance *insta
 		baseURL = fmt.Sprintf(
 			"%s/",
 			r.cfg.RegistryEndpoint,
-			instance.GetFlavor().,
+			instance.GetChunk().GetName(),
 			instance.GetFlavor().GetName(),
 		)
 		labels = map[string]string{

--- a/platformd/reconciler_test.go
+++ b/platformd/reconciler_test.go
@@ -414,8 +414,6 @@ func TestReconciler(t *testing.T) {
 						MaxAttempts:         maxAttempts,
 						SyncInterval:        100 * time.Millisecond,
 						NodeID:              nodeKey,
-						MinPort:             1,
-						MaxPort:             1,
 						WorkloadNamespace:   namespace,
 						WorkloadCPUPeriod:   cpuPeriod,
 						WorkloadCPUQuota:    cpuQuota,
@@ -425,6 +423,7 @@ func TestReconciler(t *testing.T) {
 					mockInsSvc,
 					mockWlSvc,
 					mockStore,
+					workload.NewPortAllocator(1, 1),
 				)
 			)
 

--- a/platformd/workload/port_allocator.go
+++ b/platformd/workload/port_allocator.go
@@ -16,7 +16,7 @@
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-package platformd
+package workload
 
 import (
 	"math/rand/v2"
@@ -27,7 +27,7 @@ import (
 
 var ErrMaxPortTriesReached = errors.New("maximum number of retries reached")
 
-type portAllocator struct {
+type PortAllocator struct {
 	portMin   int
 	portMax   int
 	allocated map[int]bool
@@ -35,15 +35,15 @@ type portAllocator struct {
 	mu sync.Mutex
 }
 
-func newPortAllocator(portMin, portMax uint16) *portAllocator {
-	return &portAllocator{
+func NewPortAllocator(portMin, portMax uint16) *PortAllocator {
+	return &PortAllocator{
 		allocated: make(map[int]bool),
 		portMin:   int(portMin),
 		portMax:   int(portMax),
 	}
 }
 
-func (a *portAllocator) Allocate() (uint16, error) {
+func (a *PortAllocator) Allocate() (uint16, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -68,7 +68,7 @@ func (a *portAllocator) Allocate() (uint16, error) {
 	}
 }
 
-func (a *portAllocator) Free(port uint16) {
+func (a *PortAllocator) Free(port uint16) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	delete(a.allocated, int(port))

--- a/platformd/workload/port_allocator_internal_test.go
+++ b/platformd/workload/port_allocator_internal_test.go
@@ -16,7 +16,7 @@
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-package platformd
+package workload
 
 import (
 	"testing"
@@ -31,18 +31,18 @@ func TestPortAllocation(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
-		prep func() *portAllocator
+		prep func() *PortAllocator
 	}{
 		{
 			name: "allocate multiple ports successfully",
-			prep: func() *portAllocator {
-				return newPortAllocator(1000, 2000)
+			prep: func() *PortAllocator {
+				return NewPortAllocator(1000, 2000)
 			},
 		},
 		{
 			name: "port allocation failed",
-			prep: func() *portAllocator {
-				return &portAllocator{
+			prep: func() *PortAllocator {
+				return &PortAllocator{
 					portMin: 0,
 					portMax: 2,
 					allocated: map[int]bool{

--- a/test/fixture/checkpoint.go
+++ b/test/fixture/checkpoint.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spacechunks/explorer/internal/image"
 	"github.com/spacechunks/explorer/platformd/checkpoint"
 	"github.com/spacechunks/explorer/platformd/cri"
+	"github.com/spacechunks/explorer/platformd/workload"
 	"github.com/spacechunks/explorer/test"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -73,6 +74,8 @@ func RunCheckpointAPIFixtures(t *testing.T, registryUser string, registryPass st
 			func(url string) (remotecommand.Executor, error) {
 				return &test.RemoteCmdExecutor{}, nil
 			},
+			workload.NewStore(),
+			workload.NewPortAllocator(5000, 6000),
 		)
 		checkServ = checkpoint.NewServer(svc)
 	)


### PR DESCRIPTION
this is needed, so netglue can retrieve the port
the checkpoint workload is reachable at.

this whole thing is just so checkpoints have access to the internet in order for calls to outside services to succeed.