### PR TITLE
controlplane: fix instances report update

### DIFF
--- a/controlplane/postgres/instance.go
+++ b/controlplane/postgres/instance.go
@@ -229,6 +229,7 @@ func (db *DB) ApplyStatusReports(ctx context.Context, reports []instance.StatusR
 			continue
 		}
 		toUpdate = append(toUpdate, query.BulkUpdateInstanceStateAndPortParams{
+			ID:    report.InstanceID,
 			State: query.InstanceState(report.State),
 			Port:  ptr.Pointer(int32(report.Port)),
 		})

--- a/controlplane/postgres/query.sql
+++ b/controlplane/postgres/query.sql
@@ -158,7 +158,8 @@ WHERE i.node_id = $1;
 UPDATE instances SET
     state = $1,
     port = $2,
-    updated_at = now();
+    updated_at = now()
+WHERE id = $3;
 
 -- name: BulkDeleteInstances :batchexec
 DELETE FROM instances WHERE id = $1;

--- a/controlplane/postgres/query/batch.go
+++ b/controlplane/postgres/query/batch.go
@@ -232,6 +232,7 @@ UPDATE instances SET
     state = $1,
     port = $2,
     updated_at = now()
+WHERE id = $3
 `
 
 type BulkUpdateInstanceStateAndPortBatchResults struct {
@@ -243,6 +244,7 @@ type BulkUpdateInstanceStateAndPortBatchResults struct {
 type BulkUpdateInstanceStateAndPortParams struct {
 	State InstanceState
 	Port  *int32
+	ID    string
 }
 
 func (q *Queries) BulkUpdateInstanceStateAndPort(ctx context.Context, arg []BulkUpdateInstanceStateAndPortParams) *BulkUpdateInstanceStateAndPortBatchResults {
@@ -251,6 +253,7 @@ func (q *Queries) BulkUpdateInstanceStateAndPort(ctx context.Context, arg []Bulk
 		vals := []interface{}{
 			a.State,
 			a.Port,
+			a.ID,
 		}
 		batch.Queue(bulkUpdateInstanceStateAndPort, vals...)
 	}


### PR DESCRIPTION
previously changes destined for a single row in the table would be applied to all rows due to missing
where clause.