### PR TITLE
platformd/servermon: fix platformd socket address

### DIFF
--- a/cmd/platformd/main.go
+++ b/cmd/platformd/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -21,7 +22,7 @@ func main() {
 	var (
 		logger                       = slog.New(slog.NewTextHandler(os.Stdout, nil))
 		fs                           = flag.NewFlagSet("platformd", flag.ContinueOnError)
-		proxyServiceListenSock       = fs.String("management-server-listen-sock", "/run/platformd/platformd.sock", "path to the unix domain socket to listen on") //nolint:lll
+		mgmtListenSock               = fs.String("management-server-listen-sock", "/run/platformd/platformd.sock", "path to the unix domain socket to listen on") //nolint:lll
 		mgmtSockUID                  = fs.Uint64("management-server-listen-sock-uid", 9012, "unix domain socket uid")
 		mgmtSockGID                  = fs.Uint64("management-server-listen-sock-gid", 9012, "unix domain socket gid")
 		criListenSock                = fs.String("cri-listen-sock", "/var/run/crio/crio.sock", "path to the unix domain socket the CRI is listening on")                           //nolint:lll
@@ -61,9 +62,14 @@ func main() {
 		die(logger, "failed to parse config", err)
 	}
 
+	mgmtSockURL, err := url.Parse(*mgmtListenSock)
+	if err != nil {
+		die(logger, "failed to parse management-server-listen-sock", err)
+	}
+
 	var (
 		cfg = platformd.Config{
-			ManagementServerListenSock: *proxyServiceListenSock,
+			ManagementServerListenSock: mgmtSockURL,
 			CRIListenSock:              *criListenSock,
 			EnvoyImage:                 *envoyImage,
 			CoreDNSImage:               *coreDNSImage,

--- a/platformd/config.go
+++ b/platformd/config.go
@@ -1,11 +1,12 @@
 package platformd
 
 import (
+	"net/url"
 	"time"
 )
 
 type Config struct {
-	ManagementServerListenSock string
+	ManagementServerListenSock *url.URL
 	CRIListenSock              string
 	EnvoyImage                 string
 	CoreDNSImage               string

--- a/platformd/server.go
+++ b/platformd/server.go
@@ -51,7 +51,7 @@ func NewServer(logger *slog.Logger) *Server {
 func (s *Server) Run(ctx context.Context, cfg Config) error {
 	s.logger.Info("started with config", "config", cfg)
 
-	if err := os.MkdirAll(filepath.Dir(cfg.ManagementServerListenSock), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(cfg.ManagementServerListenSock.Path), os.ModePerm); err != nil {
 		return fmt.Errorf("create dir: %w", err)
 	}
 
@@ -102,11 +102,11 @@ func (s *Server) Run(ctx context.Context, cfg Config) error {
 		wlSvc = workload.NewService(
 			s.logger,
 			workload.Config{
-				MCManagementAPIToken: cfg.WorkloadConfig.MCManagementAPIToken,
-				ServerMonImage:       cfg.WorkloadConfig.ServerMonImage,
-				PlatformdListenSock:  cfg.ManagementServerListenSock,
-				PlatformdSocketUID:   cfg.ManagementSocketUID,
-				PlatformdSocketGID:   cfg.ManagementSocketGID,
+				MCManagementAPIToken:   cfg.WorkloadConfig.MCManagementAPIToken,
+				ServerMonImage:         cfg.WorkloadConfig.ServerMonImage,
+				PlatformdListenSockURL: cfg.ManagementServerListenSock,
+				PlatformdSocketUID:     cfg.ManagementSocketUID,
+				PlatformdSocketGID:     cfg.ManagementSocketGID,
 			},
 			criSvc,
 			registryAuth,
@@ -231,14 +231,14 @@ func (s *Server) Run(ctx context.Context, cfg Config) error {
 	wg.Add(1)
 
 	g.Go(func() error {
-		unixSock, err := net.Listen("unix", cfg.ManagementServerListenSock)
+		unixSock, err := net.Listen("unix", cfg.ManagementServerListenSock.Path)
 		if err != nil {
 			s.stopCh <- struct{}{}
 			return fmt.Errorf("failed to listen on unix socket: %v", err)
 		}
 
 		if err := os.Chown(
-			cfg.ManagementServerListenSock,
+			cfg.ManagementServerListenSock.Path,
 			int(cfg.ManagementSocketUID),
 			int(cfg.ManagementSocketGID),
 		); err != nil {
@@ -288,8 +288,8 @@ func (s *Server) Run(ctx context.Context, cfg Config) error {
 					ContainerPath: "/etc/envoy/config.yaml",
 				},
 				{
-					HostPath:      cfg.ManagementServerListenSock,
-					ContainerPath: cfg.ManagementServerListenSock,
+					HostPath:      cfg.ManagementServerListenSock.Path,
+					ContainerPath: cfg.ManagementServerListenSock.Path,
 				},
 			},
 			Linux: &runtimev1.LinuxContainerConfig{

--- a/platformd/workload/config.go
+++ b/platformd/workload/config.go
@@ -1,9 +1,11 @@
 package workload
 
+import "net/url"
+
 type Config struct {
-	MCManagementAPIToken string
-	ServerMonImage       string
-	PlatformdListenSock  string
-	PlatformdSocketUID   uint64
-	PlatformdSocketGID   uint64
+	MCManagementAPIToken   string
+	ServerMonImage         string
+	PlatformdListenSockURL *url.URL
+	PlatformdSocketUID     uint64
+	PlatformdSocketGID     uint64
 }

--- a/platformd/workload/service.go
+++ b/platformd/workload/service.go
@@ -145,8 +145,8 @@ func (s *svc) RunWorkload(ctx context.Context, w Workload, attempt uint) error {
 			LogPath: fmt.Sprintf("%s_%s_%s", w.Namespace, w.ID, "servermon"),
 			Mounts: []*runtimev1.Mount{
 				{
-					HostPath:      s.cfg.PlatformdListenSock,
-					ContainerPath: s.cfg.PlatformdListenSock,
+					HostPath:      s.cfg.PlatformdListenSockURL.Path,
+					ContainerPath: s.cfg.PlatformdListenSockURL.Path,
 				},
 			},
 			Linux: &runtimev1.LinuxContainerConfig{
@@ -170,7 +170,7 @@ func (s *svc) RunWorkload(ctx context.Context, w Workload, attempt uint) error {
 				},
 				{
 					Key:   "SERVERMON_PLATFORMD_LISTEN_SOCK",
-					Value: s.cfg.PlatformdListenSock,
+					Value: s.cfg.PlatformdListenSockURL.String(),
 				},
 			},
 		},

--- a/platformd/workload/service_test.go
+++ b/platformd/workload/service_test.go
@@ -61,11 +61,11 @@ func TestRunWorkload(t *testing.T) {
 				MemoryLimitBytes: 100000,
 			},
 			cfg: workload.Config{
-				MCManagementAPIToken: "some-token",
-				ServerMonImage:       "server-mon",
-				PlatformdListenSock:  "/var/run/platform.sock",
-				PlatformdSocketUID:   1337,
-				PlatformdSocketGID:   1337,
+				MCManagementAPIToken:   "some-token",
+				ServerMonImage:         "server-mon",
+				PlatformdListenSockURL: test.MustParseURL(t, "unix:///var/run/platform.sock"),
+				PlatformdSocketUID:     1337,
+				PlatformdSocketGID:     1337,
 			},
 			attempt: 1,
 			prep: func(criService *mock.MockCriService, cfg workload.Config, w workload.Workload, attempt uint) {
@@ -125,8 +125,8 @@ func TestRunWorkload(t *testing.T) {
 							LogPath: fmt.Sprintf("%s_%s_%s", w.Namespace, w.ID, "servermon"),
 							Mounts: []*runtimev1.Mount{
 								{
-									HostPath:      cfg.PlatformdListenSock,
-									ContainerPath: cfg.PlatformdListenSock,
+									HostPath:      cfg.PlatformdListenSockURL.Path,
+									ContainerPath: cfg.PlatformdListenSockURL.Path,
 								},
 							},
 							Linux: &runtimev1.LinuxContainerConfig{
@@ -150,7 +150,7 @@ func TestRunWorkload(t *testing.T) {
 								},
 								{
 									Key:   "SERVERMON_PLATFORMD_LISTEN_SOCK",
-									Value: cfg.PlatformdListenSock,
+									Value: cfg.PlatformdListenSockURL.String(),
 								},
 							},
 						},

--- a/test/testing.go
+++ b/test/testing.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"net/url"
 	"slices"
 	"testing"
 	"time"
@@ -96,4 +97,10 @@ func CreateResourcePackZip(t *testing.T, files map[string]string) (*bytes.Buffer
 	require.NoError(t, err)
 
 	return buf, fmt.Sprintf("%x", sha1.Sum(buf.Bytes()))
+}
+
+func MustParseURL(t *testing.T, s string) *url.URL {
+	u, err := url.Parse(s)
+	require.NoError(t, err)
+	return u
 }


### PR DESCRIPTION
in the config we provided `/run/platformd/platformd.sock` which is correct when creating a unix socket listener, but when creating a grpc client this will fail. it needs to be `unix:///run/platformd/platformd.sock`.

this commit addresses this issue by using a url instead of a plain string.