### PR TITLE
controlplane: enable bungeecord forwarding only

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -72,7 +72,6 @@ func main() {
 		packModelDir             = fs.String("resource-pack-model-dir", "", "path inside the resource pack to the directory where the models will live. e.g. assets/mynamespace/models/item")       //nolint:lll
 		packItemDir              = fs.String("resource-pack-item-dir", "", "path inside the resource pack to the directory where the items will live. e.g. assets/mynamespace/items")               //nolint:lll
 		packTextureDir           = fs.String("resource-pack-texture-dir", "", "path inside the resource pack to the directory where the textures will live. e.g. assets/mynamespace/textures/item") //nolint:lll
-		velocitySecret           = fs.String("velocity-secret", "", "the velocity secret to set in the paper server configuration")                                                                 //nolint:lll
 		changeSetTarballMaxSize  = fs.Uint64("change-set-tarball-max-size", 1073741824, "the maximum allowed size in bytes of the change set tarball")                                              //nolint:lll
 		archiveInterval          = fs.Duration("archive-interval", 3*time.Minute, "in what interval the deleted chunks and flavors should be archived")                                             //nolint:lll
 		disableTracing           = fs.Bool("disable-tracing", false, "disable open telemetry tracing")                                                                                              //nolint:lll
@@ -117,7 +116,6 @@ func main() {
 			ResourcePackModelDir:          *packModelDir,
 			ResourcePackItemDir:           *packItemDir,
 			ResourcePackTextureDir:        *packTextureDir,
-			VelocitySecret:                *velocitySecret,
 			ChangeSetTarballMaxSizeBytes:  *changeSetTarballMaxSize,
 			ArchiveInterval:               *archiveInterval,
 			DisableTracing:                *disableTracing,

--- a/controlplane/config.go
+++ b/controlplane/config.go
@@ -49,7 +49,6 @@ type Config struct {
 	ResourcePackModelDir          string
 	ResourcePackItemDir           string
 	ResourcePackTextureDir        string
-	VelocitySecret                string
 	ChangeSetTarballMaxSizeBytes  uint64
 	ArchiveInterval               time.Duration
 	DisableTracing                bool

--- a/controlplane/server.go
+++ b/controlplane/server.go
@@ -55,7 +55,6 @@ import (
 	"github.com/spacechunks/explorer/controlplane/job"
 	"github.com/spacechunks/explorer/controlplane/node"
 	"github.com/spacechunks/explorer/controlplane/postgres"
-	"github.com/spacechunks/explorer/controlplane/serverconfig"
 	"github.com/spacechunks/explorer/controlplane/user"
 	"github.com/spacechunks/explorer/controlplane/worker"
 	"github.com/spacechunks/explorer/internal/image"
@@ -87,8 +86,6 @@ func NewServer(logger *slog.Logger, cfg Config) *Server {
 }
 
 func (s *Server) Run(ctx context.Context) error {
-	serverconfig.SetVelocitySecret(s.cfg.VelocitySecret)
-
 	shutdown, err := instr.SetupOTel(ctx, "control-plane", s.cfg.DisableTracing)
 	if err != nil {
 		return fmt.Errorf("setup otel: %w", err)

--- a/controlplane/serverconfig/paper.go
+++ b/controlplane/serverconfig/paper.go
@@ -7,21 +7,15 @@ import (
 	"github.com/spacechunks/explorer/controlplane/blob"
 )
 
-var secret = ""
-
-func SetVelocitySecret(s string) {
-	secret = s
-}
-
 func defaultPaperGlobalStr() string {
-	return fmt.Sprintf(`
+	return `
 proxies:
+  bungee-cord:
+    online-mode: true
   proxy-protocol: false
   velocity:
-    enabled: true
-    online-mode: true
-    secret: %s
-`, secret)
+    enabled: false
+`
 }
 
 type paperGlobal struct {
@@ -30,11 +24,12 @@ type paperGlobal struct {
 
 type proxiesConfig struct {
 	ProxyProtocol bool `json:"proxy-protocol"`
-	Velocity      struct {
-		Enabled    bool   `json:"enabled"`
-		OnlineMode bool   `json:"online-mode"`
-		Secret     string `json:"secret"`
-	}
+	BungeeCord    struct {
+		OnlineMode bool `json:"online-mode"`
+	} `json:"bungee-cord"`
+	Velocity struct {
+		Enabled bool `json:"enabled"`
+	} `json:"velocity"`
 }
 
 func sanatizePaperGlobal(data []byte) ([]byte, error) {
@@ -44,9 +39,8 @@ func sanatizePaperGlobal(data []byte) ([]byte, error) {
 	}
 
 	global.Proxies.ProxyProtocol = false
-	global.Proxies.Velocity.Enabled = true
-	global.Proxies.Velocity.OnlineMode = true
-	global.Proxies.Velocity.Secret = secret
+	global.Proxies.Velocity.Enabled = false
+	global.Proxies.BungeeCord.OnlineMode = true
 
 	ret, err := yaml.Marshal(global)
 	if err != nil {

--- a/controlplane/serverconfig/paper.go
+++ b/controlplane/serverconfig/paper.go
@@ -10,9 +10,9 @@ import (
 func defaultPaperGlobalStr() string {
 	return `
 proxies:
+  proxy-protocol: false
   bungee-cord:
     online-mode: true
-  proxy-protocol: false
   velocity:
     enabled: false
 `

--- a/controlplane/serverconfig/paper_internal_test.go
+++ b/controlplane/serverconfig/paper_internal_test.go
@@ -9,29 +9,26 @@ import (
 )
 
 func TestPaperConfigAdjustments(t *testing.T) {
-	SetVelocitySecret("secret")
-
 	input := `
 proxies:
   bungee-cord:
-    online-mode: true
+    online-mode: false
   proxy-protocol: true
   velocity:
-    enabled: false
-    online-mode: false
-    secret: "blalala"
+    enabled: true
 `
 	expectedCfg := paperGlobal{
 		Proxies: proxiesConfig{
 			ProxyProtocol: false,
-			Velocity: struct {
-				Enabled    bool   `json:"enabled"`
-				OnlineMode bool   `json:"online-mode"`
-				Secret     string `json:"secret"`
+			BungeeCord: struct {
+				OnlineMode bool `json:"online-mode"`
 			}{
-				Enabled:    true,
 				OnlineMode: true,
-				Secret:     "secret",
+			},
+			Velocity: struct {
+				Enabled bool `json:"enabled"`
+			}{
+				Enabled: false,
 			},
 		},
 	}

--- a/controlplane/serverconfig/paper_internal_test.go
+++ b/controlplane/serverconfig/paper_internal_test.go
@@ -11,9 +11,9 @@ import (
 func TestPaperConfigAdjustments(t *testing.T) {
 	input := `
 proxies:
+  proxy-protocol: true
   bungee-cord:
     online-mode: false
-  proxy-protocol: true
   velocity:
     enabled: true
 `

--- a/controlplane/serverconfig/sanatize.go
+++ b/controlplane/serverconfig/sanatize.go
@@ -67,7 +67,7 @@ func SanitizeConfigs(root *os.Root) error {
 		return fmt.Errorf("walk: %w", err)
 	}
 
-	for _, p := range []string{"config/paper-global.yml", "server.properties"} {
+	for _, p := range []string{"config/paper-global.yml", "server.properties", "spigot.yml"} {
 		if _, found := walked[p]; found {
 			continue
 		}
@@ -87,6 +87,8 @@ func writeDefaultConfig(root *os.Root, path string) error {
 		def = defaultPaperGlobalStr()
 	case "server.properties":
 		def = defaultServerPropertiesStr
+	case "spigot.yml":
+		def = defaultSpigotStr()
 	}
 
 	if def == "" {

--- a/controlplane/serverconfig/sanatize.go
+++ b/controlplane/serverconfig/sanatize.go
@@ -16,6 +16,7 @@ func init() {
 	sanatizers = map[string]sanatize{
 		"server.properties":       sanatizeServerProperties,
 		"config/paper-global.yml": sanatizePaperGlobal,
+		"spigot.yml":              sanatizeSpigot,
 	}
 }
 

--- a/controlplane/serverconfig/sanatize_test.go
+++ b/controlplane/serverconfig/sanatize_test.go
@@ -16,10 +16,10 @@ func TestSanatizeConfigs(t *testing.T) {
 	paperGlobal := `
 proxies:
   bungee-cord:
-    online-mode: true
+    online-mode: false
   proxy-protocol: true
   velocity:
-    enabled: false
+    enabled: false 
     online-mode: false
     secret: "blalala"
 `
@@ -49,17 +49,15 @@ use-native-transport=true
 	err = root.WriteFile("server.properties", []byte(properties), os.ModePerm)
 	require.NoError(t, err)
 
-	serverconfig.SetVelocitySecret("secret2")
-
 	err = serverconfig.SanitizeConfigs(root)
 	require.NoError(t, err)
 
 	expectedPaperGlobal := `proxies:
   proxy-protocol: false
-  velocity:
-    enabled: true
+  bungee-cord:
     online-mode: true
-    secret: secret2
+  velocity:
+    enabled: false
 `
 
 	expectedProperties := `log-ips = false
@@ -94,18 +92,16 @@ func TestSanatizeConfigWritesDefaultConfigs(t *testing.T) {
 	root, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
 
-	serverconfig.SetVelocitySecret("secret1")
-
 	err = serverconfig.SanitizeConfigs(root)
 	require.NoError(t, err)
 
 	expectedPaperGlobal := `
 proxies:
   proxy-protocol: false
-  velocity:
-    enabled: true
+  bungee-cord:
     online-mode: true
-    secret: secret1
+  velocity:
+    enabled: false
 `
 
 	expectedProperties := `

--- a/controlplane/serverconfig/sanatize_test.go
+++ b/controlplane/serverconfig/sanatize_test.go
@@ -104,6 +104,11 @@ proxies:
     enabled: false
 `
 
+	expectedSpigot := `
+settings:
+  bungeecord: true
+`
+
 	expectedProperties := `
 server-ip = 0.0.0.0
 server-port = 25565
@@ -124,11 +129,18 @@ use-native-transport = true
 	actualProperties, err := root.ReadFile("server.properties")
 	require.NoError(t, err)
 
+	actualSpigot, err := root.ReadFile("spigot.yml")
+	require.NoError(t, err)
+
 	if d := cmp.Diff(expectedPaperGlobal, string(actualPaperGlobal)); d != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", d)
 	}
 
 	if d := cmp.Diff(expectedProperties, string(actualProperties)); d != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", d)
+	}
+
+	if d := cmp.Diff(expectedSpigot, string(actualSpigot)); d != "" {
 		t.Fatalf("mismatch (-want +got):\n%s", d)
 	}
 }

--- a/controlplane/serverconfig/spigot.go
+++ b/controlplane/serverconfig/spigot.go
@@ -1,0 +1,37 @@
+package serverconfig
+
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spacechunks/explorer/controlplane/blob"
+)
+
+func defaultSpigotStr() string {
+	return `
+settings:
+  bungeecord: true
+`
+}
+
+type spigotCfg struct {
+	Settings struct {
+		BungeeCord bool `yaml:"bungeecord"`
+	} `json:"settings"`
+}
+
+func sanatizeSpigot(data []byte) ([]byte, error) {
+	var spigot spigotCfg
+	if err := yaml.Unmarshal(data, &blob.Object{}); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	spigot.Settings.BungeeCord = true
+
+	ret, err := yaml.Marshal(spigot)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	return ret, nil
+}

--- a/controlplane/serverconfig/spigot_test.go
+++ b/controlplane/serverconfig/spigot_test.go
@@ -1,0 +1,33 @@
+package serverconfig
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpigotConfigAdjustments(t *testing.T) {
+	input := `
+settings:
+  bungeecord: false
+`
+	expectedCfg := spigotCfg{
+		Settings: struct {
+			BungeeCord bool `yaml:"bungeecord"`
+		}{
+			BungeeCord: true,
+		},
+	}
+
+	expectedYaml, err := yaml.Marshal(expectedCfg)
+	require.NoError(t, err)
+
+	actual, err := sanatizeSpigot([]byte(input))
+	require.NoError(t, err)
+
+	if d := cmp.Diff(string(expectedYaml), string(actual)); d != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", d)
+	}
+}


### PR DESCRIPTION
we want to support 1.8 legacy servers, and for this to work we can only use the bungeecord-compatible forwarding method of velocity.