### PR TITLE
platformd: adjust log paths

### DIFF
--- a/platformd/workload/service.go
+++ b/platformd/workload/service.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	instancev1alpha1 "github.com/spacechunks/explorer/api/instance/v1alpha1"
@@ -68,7 +69,7 @@ func (s *svc) RunWorkload(ctx context.Context, w Workload, attempt uint) error {
 		},
 		Hostname:     w.Hostname, // TODO: explore if we can use the id as the hostname
 		Labels:       w.Labels,
-		LogDirectory: cri.PodLogDir,
+		LogDirectory: podLogDir(w.Instance),
 		DnsConfig: &runtimev1.DNSConfig{
 			Servers:  []string{"10.0.0.53"}, // TODO: make configurable
 			Options:  []string{"edns0", "trust-ad"},
@@ -136,8 +137,11 @@ func (s *svc) RunWorkload(ctx context.Context, w Workload, attempt uint) error {
 				UserSpecifiedImage: w.CheckpointImage,
 				Image:              w.CheckpointImage,
 			},
-			Labels:  w.Labels,
-			LogPath: fmt.Sprintf("%s_%s_%s", w.Namespace, w.ID, w.Name),
+			Labels: w.Labels,
+			// this is just a dummy value, it has no effect.
+			// the restored checkpoint creates a log file named <container-id>.log.
+			// it seems that crio simply doesn't forward the log path we set here.
+			LogPath: "mcserver.log",
 		},
 		SandboxConfig: sboxCfg,
 	}
@@ -162,7 +166,10 @@ func (s *svc) RunWorkload(ctx context.Context, w Workload, attempt uint) error {
 				UserSpecifiedImage: s.cfg.ServerMonImage,
 				Image:              s.cfg.ServerMonImage,
 			},
-			LogPath: fmt.Sprintf("%s_%s_%s", w.Namespace, w.ID, "servermon"),
+			// use a different suffix for servermon, so the log reader tooling can
+			// distinguish it from the minecraft server log. the servermon logs should
+			// not be visible for the end-user.
+			LogPath: "servermon.slog",
 			Mounts: []*runtimev1.Mount{
 				{
 					HostPath:      s.cfg.PlatformdListenSockURL.Path,
@@ -345,4 +352,25 @@ func (s *svc) WorkloadMetadata(ctx context.Context, id string) (Metadata, error)
 		FlavorVersion: codec.FlavorVersionToDomain(instance.FlavorVersion),
 		OrderedBy:     instance.OrderedBy,
 	}, nil
+}
+
+func podLogDir(ins *instancev1alpha1.Instance) string {
+	var (
+		cName = strings.ReplaceAll(ins.Chunk.Name, " ", "-")
+		fName = strings.ReplaceAll(ins.Flavor.Name, " ", "-")
+	)
+
+	cName = strings.ReplaceAll(cName, "_", "-")
+	fName = strings.ReplaceAll(fName, "_", "-")
+
+	return fmt.Sprintf("%s/%s_%s_%s_%s_%s_%s_%s",
+		cri.PodLogDir,
+		cName,
+		fName,
+		ins.FlavorVersion.Version,
+		ins.Chunk.Id,
+		ins.FlavorVersion.Id,
+		ins.Id,
+		ins.Owner.Id,
+	)
 }

--- a/platformd/workload/service_internal_test.go
+++ b/platformd/workload/service_internal_test.go
@@ -1,0 +1,137 @@
+package workload
+
+import (
+	"fmt"
+	"testing"
+
+	chunkv1alpha1 "github.com/spacechunks/explorer/api/chunk/v1alpha1"
+	instancev1alpha1 "github.com/spacechunks/explorer/api/instance/v1alpha1"
+	userv1alpha1 "github.com/spacechunks/explorer/api/user/v1alpha1"
+	"github.com/spacechunks/explorer/platformd/cri"
+)
+
+func TestPodLogDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *instancev1alpha1.Instance
+		want     string
+	}{
+		{
+			name: "clean names with no replacements needed",
+			instance: &instancev1alpha1.Instance{
+				Id: "inst-id",
+				Chunk: &chunkv1alpha1.Chunk{
+					Id:   "chunk-id",
+					Name: "mychunk",
+				},
+				Flavor: &chunkv1alpha1.Flavor{
+					Name: "myflavor",
+				},
+				FlavorVersion: &chunkv1alpha1.FlavorVersion{
+					Id:      "fv-id",
+					Version: "1.0.0",
+				},
+				Owner: &userv1alpha1.User{
+					Id: "owner-id",
+				},
+			},
+			want: fmt.Sprintf("%s/mychunk_myflavor_1.0.0_chunk-id_fv-id_inst-id_owner-id", cri.PodLogDir),
+		},
+		{
+			name: "spaces in chunk and flavor names are replaced with dashes",
+			instance: &instancev1alpha1.Instance{
+				Id: "inst-id",
+				Chunk: &chunkv1alpha1.Chunk{
+					Id:   "chunk-id",
+					Name: "my chunk",
+				},
+				Flavor: &chunkv1alpha1.Flavor{
+					Name: "my flavor",
+				},
+				FlavorVersion: &chunkv1alpha1.FlavorVersion{
+					Id:      "fv-id",
+					Version: "1.0.0",
+				},
+				Owner: &userv1alpha1.User{
+					Id: "owner-id",
+				},
+			},
+			want: fmt.Sprintf("%s/my-chunk_my-flavor_1.0.0_chunk-id_fv-id_inst-id_owner-id", cri.PodLogDir),
+		},
+		{
+			name: "underscores in chunk and flavor names are replaced with dashes",
+			instance: &instancev1alpha1.Instance{
+				Id: "inst-id",
+				Chunk: &chunkv1alpha1.Chunk{
+					Id:   "chunk-id",
+					Name: "my_chunk",
+				},
+				Flavor: &chunkv1alpha1.Flavor{
+					Name: "my_flavor",
+				},
+				FlavorVersion: &chunkv1alpha1.FlavorVersion{
+					Id:      "fv-id",
+					Version: "1.0.0",
+				},
+				Owner: &userv1alpha1.User{
+					Id: "owner-id",
+				},
+			},
+			want: fmt.Sprintf("%s/my-chunk_my-flavor_1.0.0_chunk-id_fv-id_inst-id_owner-id", cri.PodLogDir),
+		},
+		{
+			name: "spaces and underscores together are both replaced with dashes",
+			instance: &instancev1alpha1.Instance{
+				Id: "inst-id",
+				Chunk: &chunkv1alpha1.Chunk{
+					Id:   "chunk-id",
+					Name: "my chunk_name",
+				},
+				Flavor: &chunkv1alpha1.Flavor{
+					Name: "my flavor_name",
+				},
+				FlavorVersion: &chunkv1alpha1.FlavorVersion{
+					Id:      "fv-id",
+					Version: "1.21.4",
+				},
+				Owner: &userv1alpha1.User{
+					Id: "owner-id",
+				},
+			},
+			want: fmt.Sprintf("%s/my-chunk-name_my-flavor-name_1.21.4_chunk-id_fv-id_inst-id_owner-id", cri.PodLogDir),
+		},
+		{
+			name: "IDs are passed through unmodified",
+			instance: &instancev1alpha1.Instance{
+				Id: "550e8400-e29b-41d4-a716-446655440000",
+				Chunk: &chunkv1alpha1.Chunk{
+					Id:   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+					Name: "chunk",
+				},
+				Flavor: &chunkv1alpha1.Flavor{
+					Name: "flavor",
+				},
+				FlavorVersion: &chunkv1alpha1.FlavorVersion{
+					Id:      "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+					Version: "2.0.0",
+				},
+				Owner: &userv1alpha1.User{
+					Id: "6ba7b812-9dad-11d1-80b4-00c04fd430c8",
+				},
+			},
+			want: fmt.Sprintf(
+				"%s/chunk_flavor_2.0.0_6ba7b810-9dad-11d1-80b4-00c04fd430c8_6ba7b811-9dad-11d1-80b4-00c04fd430c8_550e8400-e29b-41d4-a716-446655440000_6ba7b812-9dad-11d1-80b4-00c04fd430c8", //nolint:lll
+				cri.PodLogDir,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podLogDir(tt.instance)
+			if got != tt.want {
+				t.Errorf("podLogDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/platformd/workload/service_test.go
+++ b/platformd/workload/service_test.go
@@ -23,9 +23,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	instancev1alpha1 "github.com/spacechunks/explorer/api/instance/v1alpha1"
 	"github.com/spacechunks/explorer/internal/mock"
 	"github.com/spacechunks/explorer/internal/resource"
 	"github.com/spacechunks/explorer/internal/resource/codec"
@@ -90,7 +92,7 @@ func TestRunWorkload(t *testing.T) {
 							Attempt:   uint32(attempt),
 						},
 						Hostname:     w.Hostname,
-						LogDirectory: cri.PodLogDir,
+						LogDirectory: podLogDir(w.Instance),
 						Labels:       w.Labels,
 						DnsConfig: &runtimev1.DNSConfig{
 							Servers:  []string{"10.0.0.53"},
@@ -122,7 +124,7 @@ func TestRunWorkload(t *testing.T) {
 								Image:              w.CheckpointImage,
 							},
 							Labels:  w.Labels,
-							LogPath: fmt.Sprintf("%s_%s_%s", w.Namespace, w.ID, w.Name),
+							LogPath: "mcserver.log",
 						},
 						SandboxConfig: sboxCfg,
 					}
@@ -139,7 +141,7 @@ func TestRunWorkload(t *testing.T) {
 								UserSpecifiedImage: cfg.ServerMonImage,
 								Image:              cfg.ServerMonImage,
 							},
-							LogPath: fmt.Sprintf("%s_%s_%s", w.Namespace, w.ID, "servermon"),
+							LogPath: "servermon.log",
 							Mounts: []*runtimev1.Mount{
 								{
 									HostPath:      cfg.PlatformdListenSockURL.Path,
@@ -475,4 +477,21 @@ func TestWorkloadMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func podLogDir(ins *instancev1alpha1.Instance) string {
+	var (
+		cName = strings.ReplaceAll(ins.Chunk.Name, " ", "-")
+		fName = strings.ReplaceAll(ins.Flavor.Name, " ", "-")
+	)
+	return fmt.Sprintf("%s/%s_%s_%s_%s_%s_%s_%s",
+		cri.PodLogDir,
+		cName,
+		fName,
+		ins.FlavorVersion.Version,
+		ins.Chunk.Id,
+		ins.FlavorVersion.Id,
+		ins.Id,
+		ins.Owner.Id,
+	)
 }

--- a/platformd/workload/service_test.go
+++ b/platformd/workload/service_test.go
@@ -141,7 +141,7 @@ func TestRunWorkload(t *testing.T) {
 								UserSpecifiedImage: cfg.ServerMonImage,
 								Image:              cfg.ServerMonImage,
 							},
-							LogPath: "servermon.log",
+							LogPath: "servermon.slog",
 							Mounts: []*runtimev1.Mount{
 								{
 									HostPath:      cfg.PlatformdListenSockURL.Path,


### PR DESCRIPTION
in order to make it possible to forward the logs to the user, we need to provide the log forwarder the necessary information to pin logs to a chunk, instance and owner.

we do this by setting the pod log directory to 
`<chunk-name>_<flavor_name>_<version>_<chunk-id>_<flavor-version-id>_<instance-id>_<owner-id>`