### PR TITLE
tar: explicitly use unicode nfc normalization

### DIFF
--- a/build/controlplane.dockerfile
+++ b/build/controlplane.dockerfile
@@ -9,7 +9,11 @@ RUN mkdir bin
 RUN GOEXPERIMENT=jsonv2 go build -mod vendor -o bin ./cmd/controlplane
 
 FROM alpine:3.23
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates musl-locales musl-locales-lang
+# we deal with files and we just want to make sure that no strange shit
+# happens because LANG does not support utf8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 WORKDIR /bin
 COPY --from=builder /build/bin/controlplane controlplane
 ENTRYPOINT ["/bin/controlplane"]

--- a/internal/tarhelper/tar.go
+++ b/internal/tarhelper/tar.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 func TarFiles(rootDir string, files []*os.File, dest string) error {
@@ -52,11 +54,17 @@ func TarFiles(rootDir string, files []*os.File, dest string) error {
 			"",
 		)
 
+		// force nfc file names, because if the tar file was created on some oses, macos for example,
+		// untarring on linux will create bogus file names.
+		filename := norm.NFC.String(
+			// TarFiles will also be called on windows, so we need to adjust the paths
+			filepath.ToSlash(name),
+		)
+
 		if err := tw.WriteHeader(&tar.Header{
 			Typeflag: tar.TypeReg,
-			// TarFiles will also be called in windows, so we need to adjust the paths
-			Name: filepath.ToSlash(name),
-			Size: info.Size(),
+			Name:     filename,
+			Size:     info.Size(),
 		}); err != nil {
 			return fmt.Errorf("tar header: %w", err)
 		}


### PR DESCRIPTION
when dealing with files that have chars like "öäü" in their file name, taring them on macos and un-taring them on linux leads to bogus file names. forcing nfc normalization fixes this.