### PR TITLE
platformd: send SIGUSR1 once container has been restored

### DIFF
--- a/internal/datapath/objects_internal_test.go
+++ b/internal/datapath/objects_internal_test.go
@@ -1,3 +1,5 @@
+//go:build bpf
+
 /*
 Explorer Platform, a platform for hosting and discovering Minecraft servers.
 Copyright (C) 2024 Yannic Rieger <oss@76k.io>

--- a/internal/datapath/objects_test.go
+++ b/internal/datapath/objects_test.go
@@ -1,4 +1,4 @@
-//go:build functests
+//go:build bpf
 
 /*
 Explorer Platform, a platform for hosting and discovering Minecraft servers.

--- a/platformd/cri/container_info.go
+++ b/platformd/cri/container_info.go
@@ -17,13 +17,13 @@ type RuntimeSpec struct {
 }
 
 type ContainerInfo struct {
+	Pid         int         `json:"pid"`
 	RuntimeSpec RuntimeSpec `json:"runtimeSpec"`
 }
 
 type NamespaceType string
 
 const (
-	NamespaceTypePid NamespaceType = "pid"
 	NamespaceTypeNet NamespaceType = "network"
 )
 

--- a/platformd/workload/service.go
+++ b/platformd/workload/service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	instancev1alpha1 "github.com/spacechunks/explorer/api/instance/v1alpha1"
@@ -210,6 +211,20 @@ func (s *svc) RunWorkload(ctx context.Context, w Workload, attempt uint) error {
 	}
 
 	logger.InfoContext(ctx, "started servermon container", "container_id", serverMonCtrID)
+
+	info, err := s.criService.ContainerInfo(ctx, mcCtrID)
+	if err != nil {
+		return fmt.Errorf("container info: %w", err)
+	}
+
+	proc, err := os.FindProcess(info.Pid)
+	if err != nil {
+		return fmt.Errorf("find process: %w", err)
+	}
+
+	if err := proc.Signal(syscall.SIGUSR1); err != nil {
+		return fmt.Errorf("signal process: %w", err)
+	}
 
 	return nil
 }

--- a/platformd/workload/service_test.go
+++ b/platformd/workload/service_test.go
@@ -195,7 +195,7 @@ func TestRunWorkload(t *testing.T) {
 
 				criService.EXPECT().
 					RunContainer(mocky.Anything, mcCtrReq).
-					Return("", nil)
+					Return("abc", nil)
 
 				criService.EXPECT().
 					EnsureImage(mocky.Anything, cfg.ServerMonImage, cri.Unauthenticated).
@@ -204,6 +204,12 @@ func TestRunWorkload(t *testing.T) {
 				criService.EXPECT().
 					RunContainer(mocky.Anything, serverMonCtrReq).
 					Return("", nil)
+
+				criService.EXPECT().
+					ContainerInfo(mocky.Anything, "abc").
+					Return(cri.ContainerInfo{
+						Pid: os.Getpid(),
+					}, nil)
 			},
 		},
 	}


### PR DESCRIPTION
we checkpoint the minecraft server after the plugins `onEnable` has been called. this means that upon restoring this will not be called again. to mimic this behavior and allow plugins to still run code that should be run when the server usually starts, we send the minecraft server process `SIGUSR1`. 