### PR TITLE
cli: fix thumbnail upload and wait bug

### DIFF
--- a/cli/cmd/publish/builder.go
+++ b/cli/cmd/publish/builder.go
@@ -159,9 +159,15 @@ func (b builder) build(ctx context.Context, data buildData) {
 			return
 		}
 	}
+
 }
 
 func (b builder) Wait(ctx context.Context, f func(update buildUpdate)) {
+	time.Sleep(500 * time.Millisecond) // so hingefickt unglaublich
+	if b.buildCounter.Load() == 0 {
+		return
+	}
+	fmt.Println("\nNow waiting for updates:")
 	for {
 		select {
 		case u := <-b.updates:

--- a/cli/cmd/publish/plan.go
+++ b/cli/cmd/publish/plan.go
@@ -107,12 +107,13 @@ type actionable struct {
 }
 
 type plan struct {
-	addedFlavors    []localFlavor
-	changedFlavors  []changedFlavor
-	deletedFlavors  []deletedFlavor
-	actionables     []actionable
-	conflicts       []conflict
-	updateThumbnail bool
+	addedFlavors       []localFlavor
+	changedFlavors     []changedFlavor
+	deletedFlavors     []deletedFlavor
+	actionables        []actionable
+	conflicts          []conflict
+	updateThumbnail    bool
+	chunkWillBeRemoved bool
 }
 
 func newPlan(logger *slog.Logger, cfg config.Config, supportedVersions []string, chunk *chunkv1alpha1.Chunk) plan {
@@ -282,6 +283,14 @@ func newPlan(logger *slog.Logger, cfg config.Config, supportedVersions []string,
 			return p
 		}
 
+		defer thbFile.Close()
+
+		// if we initially publish the chunk, there will be no thumbnail, so we have to upload it
+		if chunk.Thumbnail == nil {
+			p.updateThumbnail = true
+			return p
+		}
+
 		h, err := file.ComputeHashStr(thbFile)
 		if err != nil {
 			p.conflicts = append(p.conflicts, errorConflict{
@@ -293,9 +302,13 @@ func newPlan(logger *slog.Logger, cfg config.Config, supportedVersions []string,
 			return p
 		}
 
-		if chunk.Thumbnail != nil && h != chunk.Thumbnail.Hash {
+		if h != chunk.Thumbnail.Hash {
 			p.updateThumbnail = true
 		}
+	}
+
+	if len(p.addedFlavors) == 0 && len(p.changedFlavors) == 0 && len(cfg.Chunk.Flavors) == len(cfg.Chunk.Flavors) {
+		p.chunkWillBeRemoved = true
 	}
 
 	return p
@@ -366,6 +379,10 @@ func (p plan) print() {
 			sec := cli.Section()
 			sec.AddRow(cli.ColorRed + indent1 + "=> " + fl.name)
 			sec.Print()
+		}
+
+		if p.chunkWillBeRemoved {
+			fmt.Println(cli.ColorRed + "\nWARNING: THE CHUNK WILL ALSO BE DELETED (due to all flavors being deleted)")
 		}
 	}
 

--- a/cli/cmd/publish/publish.go
+++ b/cli/cmd/publish/publish.go
@@ -274,8 +274,6 @@ func NewCommand(ctx context.Context, cliCtx cli.Context) *cobra.Command {
 
 		updates := make(map[string]buildUpdate)
 
-		fmt.Println("\nNow waiting for updates:")
-
 		// this builds the following line in the terminal and redraws it once we receive an update
 		// <flavor1>: <status> | <flavor2>: <status> | <flavor3>: <status> etc...
 		b.Wait(ctx, func(u buildUpdate) {


### PR DESCRIPTION
thumbnail will be updated if the chunk is newly created.
also fix bug where we would wait for build updates even if there
are none. this can happen, if we update a thumbnail or delete a 
flavor.