### PR TITLE
fix: use explorerctl on Windows

### DIFF
--- a/.github/workflows/test-cli-installer.yml
+++ b/.github/workflows/test-cli-installer.yml
@@ -29,9 +29,11 @@ jobs:
         env:
           EXPLORER_INSTALL_DIR: ${{ runner.temp }}/explorer-bin
           NO_COLOR: 1
-        run: ./scripts/install.sh
+        run: |
+          ./scripts/install.sh
+          echo "$EXPLORER_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: run the installed CLI
-        run: $RUNNER_TEMP/explorer-bin/explorer version
+        run: explorer version
 
   windows:
     runs-on: windows-latest
@@ -42,7 +44,9 @@ jobs:
         env:
           EXPLORER_INSTALL_DIR: ${{ runner.temp }}\explorer-bin
           NO_COLOR: 1
-        run: ./scripts/install.ps1
+        run: |
+          ./scripts/install.ps1
+          $env:EXPLORER_INSTALL_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: run the installed CLI
         shell: pwsh
-        run: '& "$env:RUNNER_TEMP\explorer-bin\explorer.exe" version'
+        run: explorerctl version

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ irm https://raw.githubusercontent.com/spacechunks/explorer/main/scripts/install.
 ```
 
 This installs the latest version of the CLI.
+On Windows, use `explorerctl` instead of `explorer`.
 
 ## License
 This project uses two different licenses: AGPLv3 and LGPLv3. Everything found under under the `api/` folder is licensed under LGPLv3 while everything else is covered by AGPLv3, if not stated otherwise.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,6 +29,7 @@ irm https://raw.githubusercontent.com/spacechunks/explorer/main/scripts/install.
 ```
 
 The installer downloads the latest version of the CLI.
+On Windows, use `explorerctl` instead of `explorer`.
 
 ## Concepts
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,7 +3,7 @@
     $ErrorActionPreference = "Stop"
 
     $repositoryUrl = "https://github.com/spacechunks/explorer"
-    $binaryName = "explorer.exe"
+    $binaryName = "explorerctl.exe"
     $tempDirectory = $null
 
     function Write-Brand {
@@ -127,7 +127,7 @@
         New-Item -ItemType Directory -Path $installDirectory -Force | Out-Null
         $installedBinary = Join-Path $installDirectory $binaryName
         Copy-Item -LiteralPath $sourceBinary -Destination $installedBinary -Force
-        Write-Step "Installed explorer to $installedBinary"
+        Write-Step "Installed explorerctl to $installedBinary"
 
         $pathEntries = @($env:Path -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
         if (-not ($pathEntries | Where-Object { $_.TrimEnd("\") -ieq $installDirectory.TrimEnd("\") })) {
@@ -148,7 +148,7 @@
         Write-Host ""
         Write-Host "Explorer CLI is ready."
         Write-Host "Run " -NoNewline
-        Write-Host "explorer --help" -NoNewline
+        Write-Host "explorerctl --help" -NoNewline
         Write-Host " to get started."
         Write-Host ""
     } catch {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,6 +82,7 @@ case "$kernel" in
 	MINGW* | MSYS* | CYGWIN*)
 		operating_system="windows"
 		operating_system_label="Windows"
+		binary_name="explorerctl"
 		binary_extension=".exe"
 		;;
 	*)
@@ -176,7 +177,7 @@ step "Installed $binary_name to $installed_binary"
 printf '\n%sExplorer CLI is ready.%s\n' "$bold" "$reset"
 case ":${PATH:-}:" in
 	*":$install_dir:"*)
-		printf 'Run %sexplorer --help%s to get started.\n\n' "$bold" "$reset"
+		printf 'Run %s%s --help%s to get started.\n\n' "$bold" "$binary_name" "$reset"
 		;;
 	*)
 		printf 'Add the installation directory to your PATH:\n\n'


### PR DESCRIPTION
Installs the Windows CLI as `explorerctl` to avoid the system `explorer.exe` collision. Installer CI now runs the installed commands through `PATH`.