### PR TITLE
cli: set x-amz-checksum-sha256 header on tarball upload

### DIFF
--- a/cli/cmd/publish/builder.go
+++ b/cli/cmd/publish/builder.go
@@ -332,6 +332,7 @@ func (b builder) handleUpload(ctx context.Context, data *buildData) error {
 	}
 
 	req.ContentLength = int64(len(tarData))
+	req.Header.Set("x-amz-checksum-sha256", base64.StdEncoding.EncodeToString(digest[:]))
 
 	progReader.OnProgress(func(progress uint) {
 		b.updates <- buildUpdate{


### PR DESCRIPTION
 Sets the `x-amz-checksum-sha256` header on the tarball PUT upload request, using the same SHA-256 digest already sent to `GetUploadURL`, so S3 verifies upload integrity against the expected hash.